### PR TITLE
Refactor MIDI button handling and debounce logic

### DIFF
--- a/footswitch/Footswitch_Code.ino
+++ b/footswitch/Footswitch_Code.ino
@@ -1,169 +1,174 @@
+// ------------ CONFIG ------------
 
+// Pins: 1..6
+const int btnPins[6] = { D0, D1, D2, D3, D4, D5 };
+
+// If pressed = HIGH, keep HIGH. If your wiring is inverted, change to LOW.
+const int PRESSED_LEVEL = HIGH;
+
+// Edge-based debounce settings (for D0..D3)
+const unsigned long stableMsEdge = 60;   // input must be stable this long
+const unsigned long minGapEdge   = 120;  // min time between events per button
+
+// Sample-based settings (for D4, D5)
+const unsigned long samplePeriodMs = 220;  // how often we "take a reading"
+
+
+// ------------ STATE ------------
+
+// For edge-based buttons (indexes 0..3: D0..D3)
+int lastRawEdge[4];
+unsigned long lastChangeTimeEdge[4];
+int stableLevelEdge[4];
+unsigned long lastEventTimeEdge[4];
+
+// For sample-based buttons (indexes 4..5: D4, D5)
+int lastSampleLevel[2];              // previous sampled HIGH/LOW
+unsigned long lastSampleTime[2];     // last time we sampled
+
+// Shared Note ON/OFF state for all 6 buttons
+bool noteOn[6];
+
+// Which of the sample-based buttons (D4/D5) to check this cycle: 0 -> D4, 1 -> D5
+int whichSample = 0;
+
+
+// ------------ MIDI HELPERS ------------
+
+void sendMidiOn(uint8_t ch) {
+  byte status = 0x90 | (ch & 0x0F);   // Note On, channel ch
+  Serial1.write(&status, 1);
+  Serial.print("MIDI Note On Sent Channel ");
+  Serial.println(ch);
+}
+
+void sendMidiOff(uint8_t ch) {
+  byte status = 0x80 | (ch & 0x0F);   // Note Off, channel ch
+  Serial1.write(&status, 1);
+  Serial.print("MIDI Note Off Sent Channel ");
+  Serial.println(ch);
+}
+
+int readFilteredPin(int pin) {
+  int ones = 0;
+  const int N = 5;  // number of reads
+
+  for (int k = 0; k < N; k++) {
+    if (digitalRead(pin) == HIGH) ones++;
+    delayMicroseconds(200);  // short spacing, ~1 ms total
+  }
+
+  return (ones >= (N / 2 + 1)) ? HIGH : LOW; // majority vote
+}
+
+
+// ------------ SETUP ------------
 
 void setup() {
   Serial.begin(9600);
   Serial1.begin(31250);
-  pinMode(D0, INPUT);
-  pinMode(D1, INPUT);
-  pinMode(D2, INPUT);
-  pinMode(D3, INPUT);
-  pinMode(D4, INPUT);
-  pinMode(D5, INPUT);
-  attachInterrupt(digitalPinToInterrupt(D0), ISR0, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(D1), ISR1, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(D2), ISR2, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(D3), ISR3, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(D4), ISR4, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(D5), ISR5, CHANGE);
-  
-}
-//default states
-  volatile bool off0 = true;   
-  volatile bool off1 = true;   
-  volatile bool off2 = true;   
-  volatile bool off3 = true;   
-  volatile bool off4 = true;   
-  volatile bool off5 = true;   
-  
-//channel 0
-void MIDIOff0(){
-  byte midiNoteOff0[] = {0x80};   
-  Serial1.write(midiNoteOff0, sizeof(midiNoteOff0));
-  Serial.println("MIDI Note Off Sent Channel 0");
- 
-}
-void MIDIOn0(){
-  byte midiNoteOn0[] = {0x90};  
-  Serial1.write(midiNoteOn0, sizeof(midiNoteOn0));
-  Serial.println("MIDI Note On Sent Channel 0");
-}
 
-//channel 1
-void MIDIOff1(){
-  byte midiNoteOff1[] = {0x81}; 
-  Serial1.write(midiNoteOff1, sizeof(midiNoteOff1));
-  Serial.println("MIDI Note Off Sent Channel 1");
- 
-}
-void MIDIOn1(){
-  byte midiNoteOn1[] = {0x91}; 
-  Serial1.write(midiNoteOn1, sizeof(midiNoteOn1));
-  Serial.println("MIDI Note On Sent Channel 1");
-}
+  unsigned long now = millis();
 
-//channel 2
-void MIDIOff2(){
-  byte midiNoteOff2[] = {0x82}; 
-  Serial1.write(midiNoteOff2, sizeof(midiNoteOff2));
-  Serial.println("MIDI Note Off Sent Channel 2");
- 
-}
-void MIDIOn2(){
-  byte midiNoteOn2[] = {0x92};  
-  Serial1.write(midiNoteOn2, sizeof(midiNoteOn2));
-  Serial.println("MIDI Note On Sent Channel 2");
-}
+  // Init D0..D3 (buttons 1..4) for edge-based debounce
+  for (int i = 0; i < 4; i++) {
+    pinMode(btnPins[i], INPUT);      // keep your existing external wiring
 
-//channel 3
-void MIDIOff3(){
-  byte midiNoteOff3[] = {0x83}; 
-  Serial1.write(midiNoteOff3, sizeof(midiNoteOff3));
-  Serial.println("MIDI Note Off Sent Channel 3");
- 
-}
-void MIDIOn3(){
-  byte midiNoteOn3[] = {0x93}; 
-  Serial1.write(midiNoteOn3, sizeof(midiNoteOn3));
-  Serial.println("MIDI Note On Sent Channel 3");
-}
-
-//channel 4
-void MIDIOff4(){
-  byte midiNoteOff4[] = {0x84}; 
-  Serial1.write(midiNoteOff4, sizeof(midiNoteOff4));
-  Serial.println("MIDI Note Off Sent Channel 4");
- 
-}
-void MIDIOn4(){
-  byte midiNoteOn4[] = {0x94}; 
-  Serial1.write(midiNoteOn4, sizeof(midiNoteOn4));
-  Serial.println("MIDI Note On Sent Channel 4");
-}
-
-//channel 5
-void MIDIOff5(){
-  byte midiNoteOff5[] = {0x85};
-  Serial1.write(midiNoteOff5, sizeof(midiNoteOff5));
-  Serial.println("MIDI Note Off Sent Channel 5");
- 
-}
-void MIDIOn5(){
-  byte midiNoteOn5[] = {0x95};
-  Serial1.write(midiNoteOn5, sizeof(midiNoteOn5));
-  Serial.println("MIDI Note On Sent Channel 5");
-}
-
-
-void ISR0(){
-  if (off0){
-    MIDIOn0();
-    off0 = false;
-  } else {
-    MIDIOff0();
-    off0 = true;
+    int v = digitalRead(btnPins[i]);
+    lastRawEdge[i]        = v;
+    stableLevelEdge[i]    = v;
+    lastChangeTimeEdge[i] = now;
+    lastEventTimeEdge[i]  = 0;
+    noteOn[i]             = false;
   }
-}
- 
 
-void ISR1(){
-  if (off1){
-    MIDIOn1();
-    off1 = false;
-  } else {
-    MIDIOff1();
-    off1 = true;
-  }
-}
+// Init D4..D5 (buttons 5..6) for sample-based logic
+for (int j = 0; j < 2; j++) {
+  int idx = 4 + j;                 // 4 -> D4, 5 -> D5
 
-void ISR2(){
-  if (off2){
-    MIDIOn2();
-    off2 = false;
-  } else {
-    MIDIOff2();
-    off2 = true;
-  }
+  pinMode(btnPins[idx], INPUT_PULLDOWN);  // <--- try this first
+
+  int v = readFilteredPin(btnPins[idx]);
+  lastSampleLevel[j] = v;
+  lastSampleTime[j]  = now;
+  noteOn[idx]        = false;
 }
 
-void ISR3(){
-  if (off3){
-    MIDIOn3();
-    off3 = false;
-  } else {
-    MIDIOff3();
-    off3 = true;
-  }
+  Serial.println("6-button MIDI footswitch: D0..D3 edge-based, D4..D5 sampled.");
 }
 
-void ISR4(){
-  if (off4){
-      MIDIOn4();
-      off4 = false;
-    } else {
-      MIDIOff4();
-      off4 = true;
+
+// ------------ LOOP ------------
+
+void loop() {
+  unsigned long now = millis();
+
+  // ----- EDGE-BASED: buttons 1..4 (D0..D3, indexes 0..3) -----
+  for (int i = 0; i < 4; i++) {
+    int idx = i;  // logical index = MIDI channel = i
+
+    int raw = digitalRead(btnPins[idx]);
+
+    // track raw stability
+    if (raw != lastRawEdge[i]) {
+      lastRawEdge[i]        = raw;
+      lastChangeTimeEdge[i] = now;
     }
-}
 
-void ISR5(){
-   if (off5){
-      MIDIOn5();
-      off5 = false;
-    } else {
-      MIDIOff5();
-      off5 = true;
+    // has the raw value been different from the stable value long enough?
+    if (raw != stableLevelEdge[i] && (now - lastChangeTimeEdge[i] >= stableMsEdge)) {
+      // enforce minimum time between events
+      if (now - lastEventTimeEdge[i] < minGapEdge) {
+        // too soon after last event; update stableLevel but don't send MIDI
+        stableLevelEdge[i] = raw;
+        continue;
+      }
+
+      // accept new stable level
+      stableLevelEdge[i] = raw;
+      lastEventTimeEdge[i] = now;
+
+      bool pressed = (stableLevelEdge[i] == PRESSED_LEVEL);
+
+      if (pressed && !noteOn[idx]) {
+        sendMidiOn(idx);
+        noteOn[idx] = true;
+      } else if (!pressed && noteOn[idx]) {
+        sendMidiOff(idx);
+        noteOn[idx] = false;
+      }
     }
+  }
+
+  // ----- SAMPLE-BASED: buttons 5..6 (D4..D5, indexes 4..5) -----
+  {
+    int j   = whichSample;   // 0 or 1
+    int idx = 4 + j;         // 4 -> button 5 (D4), 5 -> button 6 (D5)
+
+    if (now - lastSampleTime[j] >= samplePeriodMs) {
+      lastSampleTime[j] = now;
+
+      int v = digitalRead(btnPins[idx]);
+      bool pressed = (v == PRESSED_LEVEL);
+
+      // compare current sample to previous sample for THIS button
+      if (v != lastSampleLevel[j]) {
+        lastSampleLevel[j] = v;
+
+        if (pressed && !noteOn[idx]) {
+          sendMidiOn(idx);
+          noteOn[idx] = true;
+        } else if (!pressed && noteOn[idx]) {
+          sendMidiOff(idx);
+          noteOn[idx] = false;
+        }
+      }
+
+      // after we’ve processed one sampled button, next cycle check the other one
+      whichSample ^= 1;  // flip between 0 and 1
+    }
+  }
+
+
+  delay(1);
 }
-
-void loop() {    
-


### PR DESCRIPTION
Define all six footswitch pins, the active level, and separate timing constants for edge- versus sample-driven debounce paths, alongside arrays that persist raw readings, stability timing, and current note-on states for each channel. For the two sampled switches on D4 and D5, also configure their pins with internal pull-up or pull-down resistors and provide a helper to read them via multiple quick samples and a majority vote, hardening them against noise and crosstalk.

During setup, capture the initial readings and timestamps for the four edge-debounced switches and the two sampled switches so that both schemes start with synchronized state and note tracking tailored to the hardware wiring and bias configuration.

In the main loop, poll the first four switches continuously, waiting for their inputs to remain stable long enough and enforcing a minimum gap before emitting MIDI note-on/off messages, ensuring only genuine presses generate events.

Alternate sampling between the final two switches on a slower cadence, using the multi-sample majority-read helper plus the previous-sample state to decide when to toggle note messages, and route both note-on and note-off commands through shared helpers that also log the activity for debugging.