### PR TITLE
Use profiles directory for profile selection

### DIFF
--- a/gui/src/qwidgets/core.py
+++ b/gui/src/qwidgets/core.py
@@ -16,7 +16,7 @@ from styles import (
     ScrollBarStyle, color_background, ControlDisplayStyle,
     BreadcrumbsBarStyle, styles_tabletitle, styles_tableitem
 )
-from utils import config_dir
+from utils import config_dir, profiles_dir
 from qwidgets.parameter_widgets import ParameterPanel
 from qwidgets.controls import ControlDisplay, RotaryEncoder
 from qwidgets.graphics_utils import SCREEN_H, SCREEN_W
@@ -80,7 +80,7 @@ class MainWindow(QWidget):
 
         board = PluginManager()
         selected_json = selected_profile + ".json"
-        json_path = os.path.join(config_dir, selected_json)
+        json_path = os.path.join(profiles_dir, selected_json)
         board.initFromJSON(json_path)
 
         # Restart mod-host so we can change profiles.
@@ -502,8 +502,8 @@ class BoxOfPlugins(QWidget):
 
 class ProfileSelectWindow(FloatingWindow):
     def __init__(self, callback):
-        self.json_dir = os.path.dirname(config_dir)
-        self.json_files = self.get_json_files(config_dir)
+        self.json_dir = profiles_dir
+        self.json_files = self.get_json_files(profiles_dir)
         self.json_files.sort()
 
         self.callback = callback
@@ -536,6 +536,10 @@ class ProfileSelectWindow(FloatingWindow):
         # Prevent last item from sticking around
         items[index].hide()
         items.pop(index)
+        removed_file = self.json_files.pop(index)
+        profile_path = os.path.join(profiles_dir, removed_file)
+        if os.path.isfile(profile_path):
+            os.remove(profile_path)
         # cleared group
         if n == 1:
             return
@@ -547,7 +551,6 @@ class ProfileSelectWindow(FloatingWindow):
         self.group.repaint()
         self.group.drawItems()
         super().update_continues()
-        # TODO: actually delete profile
 
     def get_json_files(self, directory):
         """Returns a list of all JSON files in the specified directory."""

--- a/gui/src/utils.py
+++ b/gui/src/utils.py
@@ -6,4 +6,5 @@ import sys
 src_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
 root_dir = os.path.normpath(os.path.join(src_dir, ".."))
 config_dir = os.path.join(root_dir, "config")
+profiles_dir = os.path.join(config_dir, "profiles")
 assets_dir = os.path.join(root_dir, "assets")


### PR DESCRIPTION
## Summary
- add a dedicated `profiles_dir` constant for profile storage
- load and manage profiles from the profiles directory instead of the general config folder
- remove deleted profiles from the profiles directory when selecting profiles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df2597c788329918fee220b5c9af8)