### PR TITLE
Add plugin manifest loader and catalog integration

### DIFF
--- a/gui/config/plugins/chorus.json
+++ b/gui/config/plugins/chorus.json
@@ -1,0 +1,64 @@
+{
+  "name": "Chorus",
+  "uri": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE",
+  "bypass": 0,
+  "channels": "stereo",
+  "inputs": ["audio_in_1", "audio_in_2"],
+  "outputs": ["audio_out_1", "audio_out_2"],
+  "parameters": [
+    {
+      "type": "plug",
+      "name": "Gain",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:gain",
+      "mode": "dial",
+      "default": 0.5,
+      "min": 0,
+      "max": 1
+    },
+    {
+      "type": "plug",
+      "name": "Rate",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:rate",
+      "mode": "dial",
+      "default": 2,
+      "min": 0,
+      "max": 10
+    },
+    {
+      "type": "plug",
+      "name": "Depth",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:depth",
+      "mode": "dial",
+      "default": 0.2,
+      "min": 0,
+      "max": 1
+    },
+    {
+      "type": "plug",
+      "name": "Delay",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:delay",
+      "mode": "dial",
+      "default": 7,
+      "min": 1,
+      "max": 100
+    },
+    {
+      "type": "plug",
+      "name": "FeedBack",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:feedback",
+      "mode": "dial",
+      "default": 0.2,
+      "min": 0,
+      "max": 1
+    },
+    {
+      "type": "plug",
+      "name": "Mix",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/ChorusPlugin/ChorusJUCE:mix",
+      "mode": "dial",
+      "default": 0.5,
+      "min": 0,
+      "max": 1
+    }
+  ]
+}

--- a/gui/config/plugins/distortion.json
+++ b/gui/config/plugins/distortion.json
@@ -1,0 +1,64 @@
+{
+  "name": "Distortion Normal",
+  "uri": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin",
+  "bypass": 0,
+  "channels": "stereo",
+  "inputs": ["audio_in_1", "audio_in_2"],
+  "outputs": ["audio_out_1", "audio_out_2"],
+  "parameters": [
+    {
+      "type": "plug",
+      "name": "Gain",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:gain",
+      "mode": "dial",
+      "default": 0.5,
+      "min": 0,
+      "max": 3
+    },
+    {
+      "type": "plug",
+      "name": "Mode",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:mode",
+      "mode": "selector",
+      "default": 0,
+      "min": 0,
+      "max": 5
+    },
+    {
+      "type": "plug",
+      "name": "Soft Clip 1",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:sc1",
+      "mode": "dial",
+      "default": 1,
+      "min": 1,
+      "max": 10
+    },
+    {
+      "type": "plug",
+      "name": "Soft Clip 2",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:sc2",
+      "mode": "dial",
+      "default": 0.33,
+      "min": 0,
+      "max": 0.333333
+    },
+    {
+      "type": "plug",
+      "name": "Soft Clip 3",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:sc3",
+      "mode": "dial",
+      "default": 0.5,
+      "min": 0,
+      "max": 3
+    },
+    {
+      "type": "plug",
+      "name": "Soft Clip 4",
+      "symbol": "https://github.com/AnnaAndres28/PedalboardPlugins/tree/main/DistortionPlugin:sc4",
+      "mode": "dial",
+      "default": 3,
+      "min": 1,
+      "max": 5
+    }
+  ]
+}

--- a/gui/src/plugin_manager.py
+++ b/gui/src/plugin_manager.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 
 class Parameter():
@@ -35,6 +36,27 @@ class Plugin():
 
     def add_parameter(self, parameter: Parameter):
         self.parameters.append(parameter)
+
+    def clone(self):
+        return Plugin(
+            name=self.name,
+            uri=self.uri,
+            channels=self.channels,
+            inputs=list(self.inputs),
+            outputs=list(self.outputs),
+            bypass=self.bypass,
+            paramters=[
+                Parameter(
+                    type=param.type,
+                    name=param.name,
+                    symbol=param.symbol,
+                    mode=param.mode,
+                    value=param.value,
+                    min=param.minimum,
+                    max=param.max,
+                ) for param in self.parameters
+            ]
+        )
 
 
 class PluginManager:
@@ -98,40 +120,10 @@ class PluginManager:
                     raise ValueError("Missing 'plugins' field")
 
                 for plugin_data in data["plugins"]:
-                    name = plugin_data.get("name", "plugin")
-                    if "uri" not in plugin_data:
-                        raise ValueError("No uri included")
-                    uri = plugin_data.get("uri")
-                    bypass = plugin_data.get("bypass", 0)
-                    channels = plugin_data.get("channels", "mono")
-                    inputs = plugin_data.get("inputs", ["in"])
-                    outputs = plugin_data.get("outputs", ["out"])
-
-                    parameters = []
-
-                    for param_data in plugin_data.get("parameters", []):
-                        try:
-                            parameter = Parameter(
-                                type=param_data.get("type", "lv2"),
-                                name=param_data.get("name", "parameter"),
-                                symbol=param_data["symbol"],
-                                mode=param_data.get("mode", "dial"),
-                                min=param_data["min"],
-                                max=param_data["max"],
-                                value=param_data.get("default", 1.0)
-                            )
-                            parameters.append(parameter)
-                        except KeyError as e:
-                            print(f"Skipping parameter {name} due to missing key: {e}")
-                    self.addPlugin(Plugin(
-                            name=name,
-                            uri=uri,
-                            bypass=bypass,
-                            channels=channels,
-                            inputs=inputs,
-                            outputs=outputs,
-                            paramters=parameters
-                        ))
+                    try:
+                        self.addPlugin(self.parse_plugin_data(plugin_data))
+                    except ValueError as e:
+                        print(f"Skipping plugin in {jsonFile}: {e}")
 
         except json.JSONDecodeError:
             print("Invalid JSON format!")
@@ -141,3 +133,74 @@ class PluginManager:
             return -1
         except ValueError as e:
             print(f"JSON Error: {e}")
+
+    @staticmethod
+    def parse_plugin_data(plugin_data: dict):
+        name = plugin_data.get("name", "plugin")
+        if "uri" not in plugin_data:
+            raise ValueError("No uri included")
+        uri = plugin_data.get("uri")
+        bypass = plugin_data.get("bypass", 0)
+        channels = plugin_data.get("channels", "mono")
+        inputs = plugin_data.get("inputs", ["in"])
+        outputs = plugin_data.get("outputs", ["out"])
+
+        parameters = []
+
+        for param_data in plugin_data.get("parameters", []):
+            try:
+                parameter = Parameter(
+                    type=param_data.get("type", "lv2"),
+                    name=param_data.get("name", "parameter"),
+                    symbol=param_data["symbol"],
+                    mode=param_data.get("mode", "dial"),
+                    min=param_data["min"],
+                    max=param_data["max"],
+                    value=param_data.get("default", 1.0)
+                )
+                parameters.append(parameter)
+            except KeyError as e:
+                print(f"Skipping parameter {name} due to missing key: {e}")
+        return Plugin(
+            name=name,
+            uri=uri,
+            bypass=bypass,
+            channels=channels,
+            inputs=inputs,
+            outputs=outputs,
+            paramters=parameters
+        )
+
+
+def load_plugin_manifests(manifest_dir: str):
+    plugins = []
+    if not os.path.isdir(manifest_dir):
+        return plugins
+
+    for filename in sorted(os.listdir(manifest_dir)):
+        if not filename.endswith(".json"):
+            continue
+        file_path = os.path.join(manifest_dir, filename)
+        try:
+            with open(file_path, "r") as file:
+                data = json.load(file)
+        except json.JSONDecodeError:
+            print(f"Invalid plugin manifest JSON format: {file_path}")
+            continue
+        except FileNotFoundError:
+            print(f"Manifest not found: {file_path}")
+            continue
+
+        plugin_entries = []
+        if isinstance(data, dict) and "plugins" in data:
+            plugin_entries = data["plugins"]
+        elif isinstance(data, dict):
+            plugin_entries = [data]
+
+        for plugin_data in plugin_entries:
+            try:
+                plugins.append(PluginManager.parse_plugin_data(plugin_data))
+            except ValueError as e:
+                print(f"Skipping plugin in {file_path}: {e}")
+
+    return plugins


### PR DESCRIPTION
## Summary
- add reusable parser and manifest loader for plugin definitions
- build the add-plugin table from a manifest-backed catalog while cloning selections
- seed a plugins manifest directory with sample chorus and distortion entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df695b3b88329832e3d92e2ea73ba)