### PR TITLE
Add plugin manifest generator and startup hook

### DIFF
--- a/gui/config/plugins/README.md
+++ b/gui/config/plugins/README.md
@@ -1,1 +1,70 @@
-# PedalboardPlugins
+# Plugin metadata and manifests
+
+This directory contains source material for each plugin and the manifests that
+power the GUI's plugin catalog. A small generator script converts per-plugin
+metadata into normalized manifest files that the GUI loads at startup.
+
+## Metadata files
+
+Each plugin directory may include a `metadata.json` file. The generator falls
+back to sensible defaults (name derived from folder, mono IO, empty parameter
+list) when the file is missing, but providing metadata keeps manifests accurate
+and consistent.
+
+### Supported fields
+
+```jsonc
+{
+  "name": "Readable plugin name",          // Defaults to directory name
+  "uri": "urn:multifx:my_plugin",         // Required by mod-host/LV2
+  "channels": "mono",                     // "mono" or "stereo"
+  "inputs": ["in"],                        // Input port labels
+  "outputs": ["out"],                      // Output port labels
+  "parameters": [
+    {
+      "symbol": "gain",                   // Required
+      "name": "Gain",                     // Defaults to symbol
+      "type": "lv2",                      // Defaults to "lv2"
+      "mode": "dial",                     // "dial", "button", or "selector"
+      "min": 0,                            // Required when parameters are present
+      "max": 1,                            // Required when parameters are present
+      "default": 0.5                       // Optional, defaults to 0
+    }
+  ],
+  "bypass": 0                              // Optional bypass value
+}
+```
+
+An alternative structure groups IO under `io`, which is helpful when the same
+metadata feeds other tools:
+
+```json
+{"io": {"inputs": ["inL", "inR"], "outputs": ["outL", "outR"]}}
+```
+
+The generator merges either representation, preferring `inputs`/`outputs` when
+both are present.
+
+## Generating manifests
+
+Run the generator to refresh manifests in `gui/config/plugins/manifests/`:
+
+```bash
+python gui/tools/gen_plugin_manifests.py
+```
+
+The script walks every plugin subdirectory (skipping `manifests/`), normalizes
+metadata, and writes one manifest per plugin. Each manifest is a JSON file with
+this shape:
+
+```json
+{"plugins": [{"name": "My Plugin", "uri": "urn:multifx:my_plugin", ...}]}
+```
+
+## Startup/build hook
+
+The GUI calls `ensure_plugin_manifests` during startup to regenerate manifests
+when they are missing or when a plugin's `metadata.json` file is newer than the
+existing manifest. Include the generator in your build process (for example,
+`python gui/tools/gen_plugin_manifests.py`) to ensure production images ship
+with up-to-date manifests.

--- a/gui/config/plugins/manifests/ChorusPlugin.json
+++ b/gui/config/plugins/manifests/ChorusPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "ChorusPlugin",
+      "uri": "urn:multifx:chorusplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/CompressionPlugin.json
+++ b/gui/config/plugins/manifests/CompressionPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "CompressionPlugin",
+      "uri": "urn:multifx:compressionplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/DelayPlugin.json
+++ b/gui/config/plugins/manifests/DelayPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "DelayPlugin",
+      "uri": "urn:multifx:delayplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/DistortionPlugin.json
+++ b/gui/config/plugins/manifests/DistortionPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "DistortionPlugin",
+      "uri": "urn:multifx:distortionplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/EchoPlugin.json
+++ b/gui/config/plugins/manifests/EchoPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "EchoPlugin",
+      "uri": "urn:multifx:echoplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/EnvelopePlugin.json
+++ b/gui/config/plugins/manifests/EnvelopePlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "EnvelopePlugin",
+      "uri": "urn:multifx:envelopeplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/FlangerPlugin.json
+++ b/gui/config/plugins/manifests/FlangerPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "FlangerPlugin",
+      "uri": "urn:multifx:flangerplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/FunDistortionPlugin.json
+++ b/gui/config/plugins/manifests/FunDistortionPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "FunDistortionPlugin",
+      "uri": "urn:multifx:fundistortionplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/FuzzPlugin.json
+++ b/gui/config/plugins/manifests/FuzzPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "FuzzPlugin",
+      "uri": "urn:multifx:fuzzplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/GainPlugin.json
+++ b/gui/config/plugins/manifests/GainPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "GainPlugin",
+      "uri": "urn:multifx:gainplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/PhaserPlugin.json
+++ b/gui/config/plugins/manifests/PhaserPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "PhaserPlugin",
+      "uri": "urn:multifx:phaserplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/ReverbPlugin.json
+++ b/gui/config/plugins/manifests/ReverbPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "ReverbPlugin",
+      "uri": "urn:multifx:reverbplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/SaturationPlugin.json
+++ b/gui/config/plugins/manifests/SaturationPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "SaturationPlugin",
+      "uri": "urn:multifx:saturationplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/Template.json
+++ b/gui/config/plugins/manifests/Template.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "Template",
+      "uri": "urn:multifx:template",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/config/plugins/manifests/TremoloPlugin.json
+++ b/gui/config/plugins/manifests/TremoloPlugin.json
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    {
+      "name": "TremoloPlugin",
+      "uri": "urn:multifx:tremoloplugin",
+      "channels": "mono",
+      "inputs": [
+        "in"
+      ],
+      "outputs": [
+        "out"
+      ],
+      "bypass": 0,
+      "parameters": []
+    }
+  ]
+}

--- a/gui/src/main.py
+++ b/gui/src/main.py
@@ -2,11 +2,14 @@ import sys
 import time
 from PyQt5.QtWidgets import QApplication
 import modhostmanager
+from plugin_manager import ensure_plugin_manifests
 from qwidgets.core import MainWindow
 import offboard
+from utils import plugins_dir
 
 
 def main():
+    ensure_plugin_manifests(plugins_dir)
     if offboard.try_load():
         print("Loaded data from USB drive!")
     app = QApplication(sys.argv)

--- a/gui/tools/gen_plugin_manifests.py
+++ b/gui/tools/gen_plugin_manifests.py
@@ -1,0 +1,138 @@
+"""Generate plugin manifest files from metadata.
+
+This script walks plugin configuration directories, reads per-plugin metadata,
+normalizes it into a manifest format, and writes individual JSON manifest files
+into the manifests directory.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+DEFAULT_METADATA_FILENAME = "metadata.json"
+
+
+def _load_metadata(plugin_dir: Path, metadata_filename: str) -> Dict:
+    metadata_file = plugin_dir / metadata_filename
+    if metadata_file.is_file():
+        try:
+            with metadata_file.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                if isinstance(data, dict):
+                    return data
+                print(f"Ignoring metadata in {metadata_file} (expected object)")
+        except Exception as exc:  # noqa: BLE001 - surface parsing errors
+            print(f"Failed to parse metadata for {plugin_dir.name}: {exc}")
+    slug = plugin_dir.name
+    return {
+        "name": slug.replace("_", " "),
+        "uri": f"urn:multifx:{slug.lower()}",
+        "channels": "mono",
+        "inputs": ["in"],
+        "outputs": ["out"],
+        "parameters": [],
+    }
+
+
+def _normalize_parameters(parameter_data: Iterable[dict]) -> List[dict]:
+    normalized: List[dict] = []
+    for param in parameter_data or []:
+        if not isinstance(param, dict):
+            continue
+        symbol = param.get("symbol")
+        if not symbol:
+            print("Skipping parameter without symbol in metadata")
+            continue
+        normalized.append(
+            {
+                "type": param.get("type", "lv2"),
+                "name": param.get("name", symbol),
+                "symbol": symbol,
+                "mode": param.get("mode", "dial"),
+                "min": param.get("min", 0),
+                "max": param.get("max", 1),
+                "default": param.get("default", param.get("value", 0)),
+            }
+        )
+    return normalized
+
+
+def _extract_io(metadata: Dict) -> tuple[list, list]:
+    inputs = metadata.get("inputs")
+    outputs = metadata.get("outputs")
+    if inputs is None or outputs is None:
+        io_data = metadata.get("io", {})
+        if inputs is None:
+            inputs = io_data.get("inputs", ["in"])
+        if outputs is None:
+            outputs = io_data.get("outputs", ["out"])
+    return list(inputs or ["in"]), list(outputs or ["out"])
+
+
+def _normalize_plugin_metadata(plugin_dir: Path, metadata: Dict) -> Dict:
+    inputs, outputs = _extract_io(metadata)
+    slug = plugin_dir.name
+    return {
+        "name": metadata.get("name", slug.replace("_", " ")),
+        "uri": metadata.get("uri", f"urn:multifx:{slug.lower()}"),
+        "channels": metadata.get("channels", "mono"),
+        "inputs": inputs,
+        "outputs": outputs,
+        "bypass": metadata.get("bypass", 0),
+        "parameters": _normalize_parameters(metadata.get("parameters", [])),
+    }
+
+
+def _iter_plugin_dirs(plugin_root: Path) -> Iterable[Path]:
+    for child in sorted(plugin_root.iterdir()):
+        if child.name == "manifests" or not child.is_dir():
+            continue
+        yield child
+
+
+def generate_manifests(plugin_root: Path, manifest_dir: Path, metadata_filename: str = DEFAULT_METADATA_FILENAME) -> List[Path]:
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    written: List[Path] = []
+    for plugin_dir in _iter_plugin_dirs(plugin_root):
+        metadata = _load_metadata(plugin_dir, metadata_filename)
+        plugin_entry = _normalize_plugin_metadata(plugin_dir, metadata)
+        manifest_path = manifest_dir / f"{plugin_dir.name}.json"
+        manifest_payload = {"plugins": [plugin_entry]}
+        with manifest_path.open("w", encoding="utf-8") as handle:
+            json.dump(manifest_payload, handle, indent=2)
+            handle.write("\n")
+        written.append(manifest_path)
+    return written
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate plugin manifest files")
+    parser.add_argument(
+        "--plugin-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "config" / "plugins",
+        help="Root folder that contains plugin directories",
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        type=Path,
+        default=None,
+        help="Destination directory for generated manifests (defaults to <plugin-root>/manifests)",
+    )
+    parser.add_argument(
+        "--metadata-filename",
+        type=str,
+        default=DEFAULT_METADATA_FILENAME,
+        help="Metadata filename to look for inside each plugin directory",
+    )
+    args = parser.parse_args()
+
+    manifest_dir = args.manifest_dir or args.plugin_root / "manifests"
+    manifest_paths = generate_manifests(args.plugin_root, manifest_dir, args.metadata_filename)
+    print(f"Wrote {len(manifest_paths)} manifest(s) to {manifest_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a manifest generator script that normalizes per-plugin metadata and writes manifests
- update plugin loading to auto-generate manifests when missing or stale and run this at GUI startup
- document metadata format and include generated manifest files for existing plugins

## Testing
- python gui/tools/gen_plugin_manifests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e06cb6c0c83299322b9fb6e3684c6)