### PR TITLE
Add master plugin catalog aggregation for USB sync

### DIFF
--- a/gui/src/offboard.py
+++ b/gui/src/offboard.py
@@ -2,8 +2,9 @@
 import fs
 import fs.base
 import os
-from utils import config_dir, plugins_dir, profiles_dir, root_dir
 import time
+import plugin_manager
+from utils import config_dir, plugins_dir, profiles_dir, root_dir
 
 SCAN_FOR_DIR: str = "multifx"
 
@@ -57,6 +58,8 @@ def try_load() -> bool:
 
     copy_subdir(extcfg_fs, incfg_fs, PROFILES_FOLDER)
     copy_subdir(extcfg_fs, incfg_fs, PLUGINS_FOLDER)
+
+    plugin_manager.aggregate_plugin_manifests(plugins_dir)
 
     return True
 


### PR DESCRIPTION
## Summary
- add a master plugin catalog at plugins/master_catalog.json and prefer it when loading manifests
- aggregate raw plugin manifest entries into the master catalog, merging existing catalog data and deduplicating by URI
- refresh the master catalog after USB sync so merged plugin data persists across runs

## Testing
- python -m compileall gui/src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e197313308329ace4491e5e5a64c5)