### PR TITLE
Add profile builder flow and template-based plugin adds

### DIFF
--- a/gui/src/plugin_manager.py
+++ b/gui/src/plugin_manager.py
@@ -77,6 +77,30 @@ class PluginManager:
     def addPlugin(self, plugin: Plugin):
         self.plugins.append(plugin)
 
+    @staticmethod
+    def clone_plugin(plugin: Plugin) -> Plugin:
+        parameters = []
+        for param in plugin.parameters:
+            parameters.append(Parameter(
+                type=param.type,
+                name=param.name,
+                symbol=param.symbol,
+                mode=param.mode,
+                value=param.value,
+                min=param.minimum,
+                max=param.max,
+            ))
+
+        return Plugin(
+            name=plugin.name,
+            uri=plugin.uri,
+            bypass=plugin.bypass,
+            channels=plugin.channels,
+            inputs=list(plugin.inputs),
+            outputs=list(plugin.outputs),
+            paramters=parameters,
+        )
+
     def changeParameter(self, pluginIndex: int, parameterIndex: int,
                         value: float):
         try:

--- a/gui/src/qwidgets/core.py
+++ b/gui/src/qwidgets/core.py
@@ -526,7 +526,8 @@ class BoxOfPlugins(QWidget):
             plugin = self.plugins.plugins[i]
             box = PluginBox(i, plugin, plugin.bypass)
             self.boxes.append(box)
-        self.boxes[n-1].isLast = True
+        if n > 0:
+            self.boxes[n-1].isLast = True
         self.add_plugin_box = AddPluginBox()
         self.boxes.append(self.add_plugin_box)
         self.scroll_bar = ScrollBar(RotaryEncoder.TOP)
@@ -573,10 +574,14 @@ class ProfileNameBuilder(QWidget):
 
         self.letter_label = QLabel(self.current_letter(), self)
         self.letter_label.setStyleSheet(styles_label)
+        self.letter_label.setAlignment(Qt.AlignCenter)
+        self.letter_label.setFixedWidth(self.width())
         self.letter_label.adjustSize()
 
         self.name_label = QLabel(self.display_name(), self)
         self.name_label.setStyleSheet(styles_sublabel)
+        self.name_label.setAlignment(Qt.AlignCenter)
+        self.name_label.setFixedWidth(self.width())
         self.name_label.adjustSize()
 
         self.instructions_label = QLabel(
@@ -584,31 +589,25 @@ class ProfileNameBuilder(QWidget):
             self,
         )
         self.instructions_label.setStyleSheet(styles_sublabel)
+        self.instructions_label.setAlignment(Qt.AlignCenter)
+        self.instructions_label.setFixedWidth(self.width())
+        self.instructions_label.setWordWrap(True)
         self.instructions_label.adjustSize()
 
         self.error_label = QLabel("", self)
         self.error_label.setStyleSheet(styles_error)
+        self.error_label.setAlignment(Qt.AlignCenter)
+        self.error_label.setFixedWidth(self.width())
+        self.error_label.setWordWrap(True)
         self.error_label.adjustSize()
 
         self.position_labels()
 
     def position_labels(self):
-        self.letter_label.move(
-            self.width() // 2 - self.letter_label.width() // 2,
-            int(self.height() * 0.4),
-        )
-        self.name_label.move(
-            self.width() // 2 - self.name_label.width() // 2,
-            int(self.height() * 0.6),
-        )
-        self.instructions_label.move(
-            self.width() // 2 - self.instructions_label.width() // 2,
-            int(self.height() * 0.7),
-        )
-        self.error_label.move(
-            self.width() // 2 - self.error_label.width() // 2,
-            int(self.height() * 0.75),
-        )
+        self.letter_label.move(0, int(self.height() * 0.4))
+        self.name_label.move(0, int(self.height() * 0.6))
+        self.instructions_label.move(0, int(self.height() * 0.7))
+        self.error_label.move(0, int(self.height() * 0.75))
 
     def display_name(self):
         return self.current_name if self.current_name else "_"

--- a/gui/src/qwidgets/core.py
+++ b/gui/src/qwidgets/core.py
@@ -584,10 +584,7 @@ class ProfileNameBuilder(QWidget):
         self.name_label.setFixedWidth(self.width())
         self.name_label.adjustSize()
 
-        self.instructions_label = QLabel(
-            "Q/E change letter • W add • S delete • X save",
-            self,
-        )
+        self.instructions_label = QLabel("", self)
         self.instructions_label.setStyleSheet(styles_sublabel)
         self.instructions_label.setAlignment(Qt.AlignCenter)
         self.instructions_label.setFixedWidth(self.width())


### PR DESCRIPTION
## Summary
- add an "add new profile" entry with a letter-by-letter builder to create empty profiles
- refresh the profile selector when returning to the start screen and immediately load new profiles
- clone plugins from the all_plugins.json definitions when adding them to boards

## Testing
- python -m compileall gui/src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934975c1e7883299df716cf746357ca)