### PR TITLE
Add nerd menu overlay with system diagnostics

### DIFF
--- a/gui/src/qwidgets/nerd_menu.py
+++ b/gui/src/qwidgets/nerd_menu.py
@@ -1,0 +1,98 @@
+"""A lightweight overlay for displaying debug-friendly runtime information."""
+
+from typing import Callable, Dict
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtWidgets import QLabel, QWidget
+
+from qwidgets.graphics_utils import SCREEN_H, SCREEN_W
+from styles import styles_label, styles_sublabel, styles_vallabel, styles_window
+from system_info import collect_debug_metrics
+
+
+class NerdMenu(QWidget):
+    """Overlay that can be toggled for quick runtime diagnostics."""
+
+    def __init__(self, close_callback: Callable[[], None],
+                 context_provider: Callable[[], Dict[str, str]] | None = None):
+        super().__init__()
+        self.close_callback = close_callback
+        self.context_provider = context_provider or (lambda: {})
+        self.setGeometry(0, 0, SCREEN_W, SCREEN_H)
+        self.setStyleSheet(styles_window)
+        self.setFocusPolicy(Qt.StrongFocus)
+
+        self.labels: Dict[str, QLabel] = {}
+        self._init_ui()
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_metrics)
+        self.timer.start(1000)
+
+    def _init_ui(self):
+        self.title = QLabel("NERD MENU", self)
+        self.title.setStyleSheet(styles_label)
+        self.title.adjustSize()
+        self.title.move(
+            (self.width() - self.title.width()) // 2,
+            int(self.height() * 0.08),
+        )
+
+        self.hint = QLabel("Press N to close", self)
+        self.hint.setStyleSheet(styles_sublabel)
+        self.hint.adjustSize()
+        self.hint.move(
+            (self.width() - self.hint.width()) // 2,
+            self.title.y() + self.title.height() + 10,
+        )
+
+        start_y = self.hint.y() + self.hint.height() + 20
+        row_height = 44
+        for index, field in enumerate(self._fields()):
+            label = QLabel(field, self)
+            label.setStyleSheet(styles_sublabel)
+            label.adjustSize()
+            label.move(24, start_y + index * row_height)
+
+            value = QLabel("--", self)
+            value.setStyleSheet(styles_vallabel)
+            value.adjustSize()
+            value.move(int(self.width() * 0.55), start_y + index * row_height)
+
+            self.labels[field] = value
+
+        self.update_metrics()
+
+    def _fields(self):
+        return [
+            "Power Draw",
+            "CPU Temp",
+            "CPU Freq",
+            "Load Avg",
+            "Memory",
+            "Uptime",
+            "Active Profile",
+            "Plugins Loaded",
+            "Timestamp",
+        ]
+
+    def update_metrics(self):
+        metrics = collect_debug_metrics()
+        metrics.update(self.context_provider())
+        for field in self._fields():
+            if field not in metrics:
+                continue
+            label = self.labels[field]
+            label.setText(metrics[field])
+            label.adjustSize()
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_N:
+            self.close_callback()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def closeEvent(self, event):
+        self.timer.stop()
+        return super().closeEvent(event)

--- a/gui/src/system_info.py
+++ b/gui/src/system_info.py
@@ -1,0 +1,167 @@
+"""Utility functions for gathering runtime debug information."""
+
+import os
+import time
+from typing import Dict, Iterable, Optional
+
+
+def _read_first_float(paths: Iterable[str], scale: Optional[float] = None) -> Optional[float]:
+    for path in paths:
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                raw_value = handle.read().strip()
+                if raw_value == "":
+                    continue
+                value = float(raw_value)
+                if scale:
+                    value /= scale
+                return value
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+    return None
+
+
+def read_cpu_temperature() -> Optional[float]:
+    """Return CPU temperature in Celsius if available."""
+    thermal_paths = [
+        "/sys/class/thermal/thermal_zone0/temp",
+        "/sys/class/hwmon/hwmon0/temp1_input",
+    ]
+    temp = _read_first_float(thermal_paths, scale=1000)
+    return temp
+
+
+def read_cpu_frequency() -> Optional[float]:
+    """Return CPU frequency in GHz if available."""
+    freq_paths = [
+        "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
+        "/sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq",
+    ]
+    freq_hz = _read_first_float(freq_paths)
+    if freq_hz is None:
+        return None
+    return freq_hz / 1_000_000  # to GHz
+
+
+def read_power_usage() -> Optional[float]:
+    """Return power usage in Watts if available."""
+    power_paths = [
+        "/sys/class/power_supply/BAT0/power_now",
+        "/sys/class/power_supply/AC/power_now",
+        "/sys/class/power_supply/usb/typec/power_now",
+    ]
+    power_watts = _read_first_float(power_paths, scale=1_000_000)
+    if power_watts is not None:
+        return power_watts
+
+    current = _read_first_float(
+        (
+            "/sys/class/power_supply/BAT0/current_now",
+            "/sys/class/power_supply/AC/current_now",
+            "/sys/class/power_supply/usb/typec/current_now",
+        ),
+        scale=1_000_000,
+    )
+    voltage = _read_first_float(
+        (
+            "/sys/class/power_supply/BAT0/voltage_now",
+            "/sys/class/power_supply/AC/voltage_now",
+            "/sys/class/power_supply/usb/typec/voltage_now",
+        ),
+        scale=1_000_000,
+    )
+    if current is not None and voltage is not None:
+        return current * voltage
+    return None
+
+
+def read_memory_usage() -> Optional[tuple[float, float]]:
+    """Return used and total memory in GB if available."""
+    try:
+        with open("/proc/meminfo", "r", encoding="utf-8") as handle:
+            meminfo = handle.read().splitlines()
+    except (FileNotFoundError, OSError):
+        return None
+
+    values: Dict[str, int] = {}
+    for line in meminfo:
+        parts = line.split(":")
+        if len(parts) != 2:
+            continue
+        key, value = parts
+        try:
+            values[key.strip()] = int(value.strip().split()[0])
+        except ValueError:
+            continue
+
+    total_kb = values.get("MemTotal")
+    available_kb = values.get("MemAvailable")
+    if total_kb is None or available_kb is None:
+        return None
+
+    used_kb = total_kb - available_kb
+    return used_kb / 1_048_576, total_kb / 1_048_576  # to GB
+
+
+def read_load_average() -> Optional[tuple[float, float, float]]:
+    try:
+        return os.getloadavg()
+    except (OSError, AttributeError):
+        return None
+
+
+def read_uptime() -> Optional[float]:
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as handle:
+            uptime_seconds = float(handle.read().split()[0])
+        return uptime_seconds
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+
+
+def format_duration(seconds: float) -> str:
+    seconds = int(seconds)
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    days, hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def collect_debug_metrics() -> Dict[str, str]:
+    metrics: Dict[str, str] = {}
+
+    if (power := read_power_usage()) is not None:
+        metrics["Power Draw"] = f"{power:.2f} W"
+    else:
+        metrics["Power Draw"] = "n/a"
+
+    if (temp := read_cpu_temperature()) is not None:
+        metrics["CPU Temp"] = f"{temp:.1f} °C"
+    else:
+        metrics["CPU Temp"] = "n/a"
+
+    if (freq := read_cpu_frequency()) is not None:
+        metrics["CPU Freq"] = f"{freq:.2f} GHz"
+    else:
+        metrics["CPU Freq"] = "n/a"
+
+    if (load := read_load_average()) is not None:
+        metrics["Load Avg"] = ", ".join(f"{value:.2f}" for value in load)
+    else:
+        metrics["Load Avg"] = "n/a"
+
+    if (memory := read_memory_usage()) is not None:
+        used, total = memory
+        metrics["Memory"] = f"{used:.2f} / {total:.2f} GB"
+    else:
+        metrics["Memory"] = "n/a"
+
+    if (uptime := read_uptime()) is not None:
+        metrics["Uptime"] = format_duration(uptime)
+    else:
+        metrics["Uptime"] = "n/a"
+
+    metrics["Timestamp"] = time.strftime("%H:%M:%S")
+    return metrics


### PR DESCRIPTION
## Summary
- add a keyboard-triggered nerd menu overlay for quick debugging information
- display system metrics such as power draw, CPU temperature/frequency, load, memory, and uptime with live updates
- include context about the active profile and plugin count in the overlay

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a3438f16883298e7d88ef6dc4b3bf)